### PR TITLE
fix(ci): Add issues write permissions to issue workflows

### DIFF
--- a/.github/workflows/issue-ai-attribution-check.yml
+++ b/.github/workflows/issue-ai-attribution-check.yml
@@ -7,6 +7,8 @@ jobs:
   check-attribution:
     name: Detect AI Attribution in Issues
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     steps:
       - name: Check for AI attribution markers
         uses: actions/github-script@v7

--- a/.github/workflows/issue-format-check.yml
+++ b/.github/workflows/issue-format-check.yml
@@ -7,6 +7,8 @@ jobs:
   check-format:
     name: Validate Issue Format
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     steps:
       - name: Check issue completeness
         uses: actions/github-script@v7

--- a/.github/workflows/issue-prd-reminder.yml
+++ b/.github/workflows/issue-prd-reminder.yml
@@ -7,6 +7,8 @@ jobs:
   check-prd-requirement:
     name: Check PRD/PDR Requirement
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     # Only run on new feature requests or enhancements
     if: contains(github.event.issue.labels.*.name, 'enhancement') || contains(github.event.issue.labels.*.name, 'feature')
     steps:


### PR DESCRIPTION
## Problem

Issue workflows were failing with "403 Resource not accessible by integration" when trying to create comments or add labels.

## Root Cause

GitHub Actions workflows require explicit  to interact with issues.

## Solution

Added  block to 3 workflows:
- 
- 
- 

## Testing

- ✅ Workflows detected issues correctly (logic working)
- ❌ Permission error prevented comments (now fixed)
- 🔄 Will test with issues #89 and #90 after merge

## Impact

After merge, workflows will be able to:
- Post helpful comments on issues
- Add appropriate labels
- Enforce project standards automatically