### PR TITLE
fix: resolve test failures (Issue #146)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -13,6 +13,7 @@ COMPONENTS=(
 	"vpn-error-handler"
 	"vpn-utils"
 	"vpn-colors"
+	"vpn-validators"
 	"best-vpn-profile"
 )
 

--- a/src/vpn-connector
+++ b/src/vpn-connector
@@ -156,8 +156,8 @@ rebuild_cache() {
     local temp_cache
     temp_cache=$(mktemp "${cache_file}.XXXXXXXXXX") || return 1
 
-    # Ensure cleanup on any exit
-    trap 'rm -f "$temp_cache"' RETURN
+    # Ensure cleanup on any exit (use ${temp_cache:-} to handle unbound variable in strict mode)
+    trap 'rm -f "${temp_cache:-}"' RETURN
 
     # Security: Set restrictive permissions immediately after creation
     chmod 600 "$temp_cache" || {


### PR DESCRIPTION
## Summary

Fixes all 3 pre-existing test failures identified in Issue #146, achieving 100% test pass rate (115/115 tests).

## Root Causes

### 1. Unbound Variable in rebuild_cache() Trap
**Problem**: The `trap 'rm -f "$temp_cache"' RETURN` in `rebuild_cache()` function failed in strict mode (`set -u`) when the trap executed with an unbound variable.

**Solution**: Changed trap to use `${temp_cache:-}` parameter expansion to provide an empty default value, making it safe in strict mode.

**Files**: `src/vpn-connector:160`

### 2. Missing vpn-validators in Installation
**Problem**: The `validate_and_discover_processes()` function exists in source (`src/vpn-validators`) but wasn't being installed to `/usr/local/bin/`, causing "command not found" errors in `hierarchical_process_cleanup()`.

**Solution**: Added `vpn-validators` to the `COMPONENTS` array in `install.sh` to ensure it's included in installations.

**Files**: `install.sh:16`

## Test Results

**Before**:
- Total: 115 tests
- Passed: 112 (97%)
- Failed: 3

**After**:
- Total: 115 tests  
- Passed: 115 (100%) ✅
- Failed: 0

## Fixed Tests

1. ✅ **Profile Listing Integration**: Should show profiles header
   - Now handles empty directories gracefully without trap errors
   
2. ✅ **Error Recovery Scenarios**: Should handle empty directory
   - Proper error handling with fixed trap variable scoping
   
3. ✅ **Pre-Connection Safety Integration**: safety command accessibility
   - `vpn cleanup` and `vpn status` commands now work correctly

## Testing

All 115 tests passing locally:
- Unit tests: ✅
- Integration tests: ✅  
- End-to-end tests: ✅
- Realistic connection tests: ✅
- Process safety tests: ✅

## Impact

- **No breaking changes**
- **No new functionality** (bug fixes only)
- **Minimal code changes** (3 lines)
- **High impact** (unblocks CI for all future PRs)

Fixes #146