### PR TITLE
fix(vpn-utils): handle missing log_file argument in log_message

### DIFF
--- a/src/vpn-manager
+++ b/src/vpn-manager
@@ -797,7 +797,7 @@ full_cleanup() {
 
 emergency_network_reset() {
     echo -e "\033[1;31m⚠️  EMERGENCY NETWORK RESET - This will disrupt internet temporarily!\033[0m"
-    log_message "Emergency network reset requested"
+    log_message "Emergency network reset requested" "$VPN_LOG_FILE"
 
     full_cleanup
 
@@ -816,7 +816,7 @@ emergency_network_reset() {
 
     echo -e "\033[1;32m✓ Emergency network reset completed\033[0m"
     echo -e "\033[1;33m  Your internet connection should recover in a few seconds.\033[0m"
-    log_message "Emergency network reset completed"
+    log_message "Emergency network reset completed" "$VPN_LOG_FILE"
 
     notify_event "process_health" "Emergency network reset"
 }

--- a/src/vpn-utils
+++ b/src/vpn-utils
@@ -15,16 +15,26 @@ notify_event() {
 # Log message function with timestamp
 # Usage: log_message "message" "log_file_path"
 # Format: [YYYY-MM-DD HH:MM:SS] message
+# Note: If log_file is omitted, outputs to stderr only
 log_message() {
     local message="$1"
-    local log_file="$2"
+    local log_file="${2:-}"
+
+    local timestamp
+    timestamp="[$(date '+%Y-%m-%d %H:%M:%S')]"
+
+    # If no log file specified, output to stderr only
+    if [[ -z "$log_file" ]]; then
+        echo "$timestamp $message" >&2
+        return 0
+    fi
 
     # Try to write to log file
-    if echo "[$(date '+%Y-%m-%d %H:%M:%S')] $message" >> "$log_file" 2> /dev/null; then
+    if echo "$timestamp $message" >> "$log_file" 2> /dev/null; then
         return 0
     else
         # Fallback to stderr if log file not writable
-        echo "[$(date '+%Y-%m-%d %H:%M:%S')] $message" >&2
+        echo "$timestamp $message" >&2
         return 0
     fi
 }


### PR DESCRIPTION
## Summary
- Fix unbound variable error when `log_message()` called without log file argument
- `emergency-reset` command now works properly

## Problem
After sleep/wake, when trying to recover VPN with `vpn emergency-reset`:
```
/usr/local/bin/vpn-utils: line 20: $2: unbound variable
```

The command crashed before it could even attempt recovery.

## Solution
- Make `log_file` parameter optional with `${2:-}`
- Fall back to stderr when no log file specified
- Belt-and-suspenders: also pass `$VPN_LOG_FILE` explicitly in `emergency_network_reset()`

## Testing
- Verified fix works with `set -u` (strict mode)
- All pre-commit hooks pass
- Test suite: 112/115 passing (97%) - 3 pre-existing failures unrelated to this change

## Test Commands
```bash
# Before fix
vpn emergency-reset  # Crashed with unbound variable

# After fix
vpn emergency-reset  # Works, restarts NetworkManager
```

Fixes #221