### PR TITLE
fix(validators): match OpenVPN processes with full path

### DIFF
--- a/src/vpn-validators
+++ b/src/vpn-validators
@@ -311,7 +311,8 @@ validate_openvpn_process() {
     fi
     local cmd_line
     cmd_line=$(ps -p "$pid" -o cmd= 2> /dev/null || true)
-    [[ "$cmd_line" =~ ^openvpn.*--config ]]
+    # Match openvpn with full path (/usr/bin/openvpn) or just binary name
+    [[ "$cmd_line" =~ (^|/)openvpn.*--config ]]
 }
 
 # Discover all VPN-related processes including zombies


### PR DESCRIPTION
## Summary
Fix cleanup/emergency-reset silently failing to kill OpenVPN processes.

## Problem
The `validate_openvpn_process()` regex used `^openvpn` which doesn't match `/usr/bin/openvpn`. This caused cleanup to skip killable processes:

```
Cleanup escalation level: sudo
  Remaining processes after sudo: 899
```

The process was actually in S-state (killable), but validation rejected it.

## Solution
Changed regex from `^openvpn.*--config` to `(^|/)openvpn.*--config` to match both:
- `openvpn --config ...` (bare command)
- `/usr/bin/openvpn --config ...` (full path)

## Testing
```bash
# Before: validation fails
cmd_line="/usr/bin/openvpn --config /path"
[[ "$cmd_line" =~ ^openvpn.*--config ]]  # false

# After: validation passes
[[ "$cmd_line" =~ (^|/)openvpn.*--config ]]  # true
```

Fixes #225